### PR TITLE
Years implementation

### DIFF
--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -1,4 +1,7 @@
 DaysPerSeason: 30
+YearsEnabled: true
+StartingYear: 2000
+SeasonsPerYear: 4
 SecondsOfDamage: 3
 CustomWeathers: true
 RoofHeight: 10
@@ -6,6 +9,7 @@ ActionBar: true
 TitleMessages:
     season: false
     weather: false
+    year: false
 disabled-worlds:
     - 'world_nether'
     - 'world_the_end'

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ main: uk.co.harieo.seasons.core.SeasonsCore
 version: 2.5.1
 name: Seasons
 author: Harieo
+api-version: 1.13
 softdepend:
   - 'PlaceholderAPI'
 
@@ -15,6 +16,8 @@ commands:
     description: Changes the weather in a world
   changeseason:
     description: Changes the season in a world
+  changeyear:
+    description: Changes the year in a world
 
 permissions:
   seasons.*:
@@ -39,6 +42,9 @@ permissions:
     default: op
   seasons.change.season:
     description: Change the season in a world
+    default: op
+  seasons.change.year:
+    description: Change the year in a world
     default: op
   seasons.reload:
     description: Reload the configuration for seasons

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/SeasonalListener.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/SeasonalListener.java
@@ -7,13 +7,28 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.WorldLoadEvent;
 
+import uk.co.harieo.seasons.plugin.configuration.StaticPlaceholders;
 import uk.co.harieo.seasons.plugin.events.DayEndEvent;
 import uk.co.harieo.seasons.plugin.events.SeasonChangeEvent;
 import uk.co.harieo.seasons.plugin.events.SeasonsWeatherChangeEvent;
+import uk.co.harieo.seasons.plugin.events.YearChangeEvent;
 import uk.co.harieo.seasons.plugin.models.Season;
 import uk.co.harieo.seasons.plugin.models.Weather;
 
 public class SeasonalListener implements Listener {
+
+	@EventHandler
+	public void onYearChange(YearChangeEvent event) {
+		World world = event.getCycle().getWorld();
+		Seasons.getInstance().getLanguageConfig()
+				.getStringOrDefault("year-trigger", "Entered the %year% year")
+				.map(message -> message.replaceAll(StaticPlaceholders.YEAR.toString(), String.valueOf(event.getChangedTo())))
+				.ifPresent(message -> {
+					for (Player player : world.getPlayers()) {
+						player.sendMessage(Seasons.PREFIX + message);
+					}
+				});
+	}
 
 	@EventHandler
 	public void onSeasonChange(SeasonChangeEvent event) {

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/Seasons.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/Seasons.java
@@ -86,6 +86,7 @@ public class Seasons {
 			setCommandExecutor("changeday", changeCommand);
 			setCommandExecutor("changeweather", changeCommand);
 			setCommandExecutor("changeseason", changeCommand);
+			setCommandExecutor("changeyear", changeCommand);
 
 			PluginManager pluginManager = Bukkit.getPluginManager();
 			pluginManager.registerEvents(new SeasonalListener(), plugin);

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/WorldTicker.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/WorldTicker.java
@@ -8,6 +8,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import uk.co.harieo.seasons.plugin.events.DayEndEvent;
 import uk.co.harieo.seasons.plugin.events.SeasonChangeEvent;
 import uk.co.harieo.seasons.plugin.events.SeasonsWeatherChangeEvent;
+import uk.co.harieo.seasons.plugin.events.YearChangeEvent;
 import uk.co.harieo.seasons.plugin.models.Cycle;
 import uk.co.harieo.seasons.plugin.models.Season;
 import uk.co.harieo.seasons.plugin.models.Weather;
@@ -50,11 +51,23 @@ public class WorldTicker extends BukkitRunnable {
 	 * @param cycle to advance the day on
 	 */
 	private void newDay(Cycle cycle) {
+		int year;
 		int day = cycle.getDay();
 		Season season;
 
 		// If the next day will advance past the amount of days in a season, switch to new season
 		if (day + 1 > Seasons.getInstance().getSeasonsConfig().getDaysPerSeason()) {
+			if (Seasons.getInstance().getSeasonsConfig().isYearsEnabled()) {
+				int seasonOfYear = cycle.getSeasonOfYear();
+				if (seasonOfYear + 1 > Seasons.getInstance().getSeasonsConfig().getSeasonsPerYear()) {
+					year = cycle.getYear() + 1;
+					Bukkit.getPluginManager().callEvent(new YearChangeEvent(cycle, year, cycle.getYear(), true));
+					cycle.setYear(year);
+					cycle.setSeasonOfYear(1);
+				} else {
+					cycle.setSeasonOfYear(seasonOfYear + 1);
+				}
+			}
 			cycle.setDay(1);
 			season = Season.next(cycle.getSeason());
 			Bukkit.getPluginManager().callEvent(new SeasonChangeEvent(cycle, season, cycle.getSeason(), true));

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/actionbar/SeasonsActionBar.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/actionbar/SeasonsActionBar.java
@@ -28,7 +28,7 @@ public class SeasonsActionBar implements Runnable {
 			if (cycle != null) {
 				Season season = cycle.getSeason();
 				Weather weather = cycle.getWeather();
-				ComponentBuilder builder = new ComponentBuilder();
+				ComponentBuilder builder = new ComponentBuilder("");
 				if (Seasons.getInstance().getSeasonsConfig().isYearsEnabled()) {
 					builder.append(Seasons.getInstance().getLanguageConfig().getString("misc.year-color")
 										   .orElse(String.valueOf(ChatColor.RED))

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/actionbar/SeasonsActionBar.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/actionbar/SeasonsActionBar.java
@@ -1,5 +1,6 @@
 package uk.co.harieo.seasons.plugin.actionbar;
 
+import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -27,11 +28,18 @@ public class SeasonsActionBar implements Runnable {
 			if (cycle != null) {
 				Season season = cycle.getSeason();
 				Weather weather = cycle.getWeather();
+				ComponentBuilder builder = new ComponentBuilder();
+				if (Seasons.getInstance().getSeasonsConfig().isYearsEnabled()) {
+					builder.append(Seasons.getInstance().getLanguageConfig().getString("misc.year-color")
+										   .orElse(String.valueOf(ChatColor.RED))
+										   + cycle.getYear())
+							.append("∙ ").color(ChatColor.GRAY);
+				}
 				player.spigot().sendMessage(ChatMessageType.ACTION_BAR,
-						new ComponentBuilder(season.getName()).color(season.getColor().asBungee())
-								.append("∙ ").color(ChatColor.GRAY)
-								.append(weather.getName())
-								.create());
+											builder.append(season.getName()).color(season.getColor().asBungee())
+													.append("∙ ").color(ChatColor.GRAY)
+													.append(weather.getName())
+													.create());
 			}
 		}
 	}

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/actionbar/TitleMessageHandler.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/actionbar/TitleMessageHandler.java
@@ -16,12 +16,14 @@ import java.util.function.Consumer;
 import uk.co.harieo.seasons.plugin.Seasons;
 import uk.co.harieo.seasons.plugin.events.SeasonChangeEvent;
 import uk.co.harieo.seasons.plugin.events.SeasonsWeatherChangeEvent;
+import uk.co.harieo.seasons.plugin.events.YearChangeEvent;
 import uk.co.harieo.seasons.plugin.models.Cycle;
 import uk.co.harieo.seasons.plugin.models.Season;
 import uk.co.harieo.seasons.plugin.models.Weather;
 
 public class TitleMessageHandler implements Listener {
 
+	private static boolean YEAR_CHANGE = false;
 	private static boolean SEASON_CHANGE = false;
 	private static boolean WEATHER_CHANGE = false;
 
@@ -33,7 +35,7 @@ public class TitleMessageHandler implements Listener {
 			Weather weather = event.getChangedTo();
 			consumeCyclePlayers(player -> {
 				UUID uuid = player.getUniqueId();
-				if (buffer.contains(uuid)) { // If a season change title is showing
+				if (buffer.contains(uuid)) { // If a season/year change title is showing
 					buffer.remove(uuid); // Buffer only applies once
 					return; // As they are buffered, skip this title because another is already showing
 				}
@@ -51,6 +53,12 @@ public class TitleMessageHandler implements Listener {
 		if (SEASON_CHANGE) {
 			Season season = event.getChangedTo();
 			consumeCyclePlayers(player -> {
+				UUID uuid = player.getUniqueId();
+				if (buffer.contains(uuid)) { // If a year change title is showing
+					buffer.remove(uuid); // Buffer only applies once
+					return; // As they are buffered, skip this title because another is already showing
+				}
+
 				player.sendTitle(season.getName(),
 						Seasons.getInstance().getLanguageConfig().getString("misc.season-change")
 								.orElse(ChatColor.GRAY + "The season has changed"),
@@ -60,8 +68,27 @@ public class TitleMessageHandler implements Listener {
 		}
 	}
 
+	@EventHandler
+	public void onYearChange(YearChangeEvent event) {
+		if (YEAR_CHANGE) {
+			int year = event.getChangedTo();
+			consumeCyclePlayers(player -> {
+				player.sendTitle(Seasons.getInstance().getLanguageConfig().getString("misc.year-color")
+										 .orElse(String.valueOf(ChatColor.RED)) + year,
+								 Seasons.getInstance().getLanguageConfig().getString("misc.year-change")
+										 .orElse(ChatColor.GRAY + "The year has changed"),
+								 10, 70, 20);
+				buffer.add(player.getUniqueId());
+			}, event.getCycle());
+		}
+	}
+
 	private void consumeCyclePlayers(Consumer<Player> playerConsumer, Cycle cycle) {
 		cycle.getWorld().getPlayers().forEach(playerConsumer);
+	}
+
+	public static void setOnYearChange(boolean enabled) {
+		YEAR_CHANGE = enabled;
 	}
 
 	public static void setOnSeasonChange(boolean enabled) {

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/commands/ChangeCommand.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/commands/ChangeCommand.java
@@ -16,6 +16,7 @@ import uk.co.harieo.seasons.plugin.configuration.StaticPlaceholders;
 import uk.co.harieo.seasons.plugin.events.DayEndEvent;
 import uk.co.harieo.seasons.plugin.events.SeasonChangeEvent;
 import uk.co.harieo.seasons.plugin.events.SeasonsWeatherChangeEvent;
+import uk.co.harieo.seasons.plugin.events.YearChangeEvent;
 import uk.co.harieo.seasons.plugin.models.Cycle;
 import uk.co.harieo.seasons.plugin.models.Season;
 import uk.co.harieo.seasons.plugin.models.Weather;
@@ -167,6 +168,40 @@ public class ChangeCommand implements CommandExecutor {
 					Seasons.PREFIX + ChatColor.GREEN + "Successfully " + ChatColor.GRAY + "changed the season to "
 							+ ChatColor.YELLOW + season.getName() + ChatColor.GRAY + " in " + ChatColor.LIGHT_PURPLE
 							+ world.getName());
+		} else if (commandLabel.equalsIgnoreCase("changeyear")) {
+			if (hasInsufficientPermissions(sender, "seasons.change.year")) {
+				SeasonsCommand.sendPermissionDenied(sender);
+				return;
+			}
+
+			if (!Seasons.getInstance().getSeasonsConfig().isYearsEnabled()) {
+				sender.sendMessage(Seasons.PREFIX + ChatColor.RED + "Years are disabled in the config!");
+				return;
+			}
+
+			int newYear;
+			try {
+				newYear = Integer.parseInt(name);
+			} catch (NumberFormatException ignored) {
+				sender.sendMessage(Seasons.PREFIX
+										   + ChatColor.RED + "Invalid argument: Expected number value /changeyear <value>");
+				return;
+			}
+
+			manager.callEvent(new YearChangeEvent(cycle, newYear, cycle.getYear(), false));
+			cycle.setYear(newYear);
+			languageConfiguration.getStringOrDefault("command.force-year",
+													 ChatColor.GRAY + "Time shatters before you, years fly by and it is now Year " + ChatColor.LIGHT_PURPLE
+															 + newYear)
+					.ifPresent(message -> broadcast(world,
+													Seasons.PREFIX + message
+															.replaceAll(StaticPlaceholders.YEAR.toString(), String.valueOf(newYear))));
+
+			// Confirm to the sender, who may not be in the world
+			sender.sendMessage(
+					Seasons.PREFIX + ChatColor.GREEN + "Successfully " + ChatColor.GRAY + "changed the year to "
+							+ ChatColor.YELLOW + newYear + ChatColor.GRAY + " in " + ChatColor.LIGHT_PURPLE + world
+							.getName());
 		} else {
 			throw new IllegalArgumentException("A command was sent called " + command + " but couldn't be processed");
 		}

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/commands/SeasonsCommand.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/commands/SeasonsCommand.java
@@ -175,10 +175,23 @@ public class SeasonsCommand implements CommandExecutor {
 				replaced = replaced
 						.replace(StaticPlaceholders.MAX_DAYS.toString(),
 								String.valueOf(seasons.getSeasonsConfig().getDaysPerSeason()));
+				if (seasons.getSeasonsConfig().isYearsEnabled()) {
+					replaced = replaced.replace(StaticPlaceholders.YEAR.toString(), String.valueOf(cycle.getYear()));
+					replaced = replaced.replace(StaticPlaceholders.SEASON_NUMBER.toString(), String.valueOf(cycle.getSeasonOfYear()));
+					replaced = replaced
+							.replace(StaticPlaceholders.SEASONS_PER_YEAR.toString(),
+									 String.valueOf(seasons.getSeasonsConfig().getSeasonsPerYear()));
+				}
 				return replaced;
 			}).collect(Collectors.toList()).forEach(player::sendMessage);
 		} else {
-			player.sendMessage(season.getColor() + "Your world is in " + season.getName());
+			player.sendMessage(season.getColor() + "Your world is in " + season.getName()
+					+ (seasons.getSeasonsConfig().isYearsEnabled()
+					   ?
+					(ChatColor.GRAY + " - " + ChatColor.RED + cycle.getYear() + ChatColor.GRAY
+					+ " - " + ChatColor.GREEN + cycle.getSeasonOfYear() + ChatColor.GRAY + "/"
+					+ ChatColor.GREEN + seasons.getSeasonsConfig().getSeasonsPerYear())
+					   : ""));
 			player.sendMessage(ChatColor.GREEN + "The weather is currently " + ChatColor.DARK_GREEN
 					+ cycle.getWeather().getName());
 			player.sendMessage(ChatColor.GOLD + "Today is day " + cycle.getDay()

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/commands/SeasonsInfoSubcommand.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/commands/SeasonsInfoSubcommand.java
@@ -19,6 +19,9 @@ class SeasonsInfoSubcommand {
 		sender.sendMessage(Seasons.PREFIX + ChatColor.GRAY + "Your Configuration Settings (from config.yml):");
 
 		sender.sendMessage(createOptionMessage("Days per Season", String.valueOf(config.getDaysPerSeason())));
+		sender.sendMessage(createOptionMessage("Years are Enabled", String.valueOf(config.isYearsEnabled())));
+		sender.sendMessage(createOptionMessage("Starting Year", String.valueOf(config.getStartingYear())));
+		sender.sendMessage(createOptionMessage("Seasons per Year", String.valueOf(config.getSeasonsPerYear())));
 		sender.sendMessage(createOptionMessage("Seconds per Damage", String.valueOf(config.getSecondsPerDamage())));
 		sender.sendMessage(createOptionMessage("Roof Height", String.valueOf(config.getRoofHeight())));
 		sender.sendMessage(createOptionMessage("Effects are Enabled", String.valueOf(config.hasEnabledEffects())));

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/configuration/SeasonsConfig.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/configuration/SeasonsConfig.java
@@ -16,9 +16,12 @@ public class SeasonsConfig implements ConfigurationProvider {
 
 	private double currentVersion;
 	private int daysPerSeason; // Days that must go by before the world moves to the next season
+	private int startingYear; // The year that the world starts on
+	private int seasonsPerYear; // The amount of seasons that must pass before the year increases
 	private int secondsPerDamage; // Whether to activate the effects of the seasonal weathers
 	private int roofHeight; // The height of the roof that would prevent an effect from the sky
 	private boolean enableEffects; // How many ticks per damage dealt to a player on a harmful weather
+	private boolean yearsEnabled; // Whether to enable the years system
 	private List<String> disabledWorlds;
 	private List<String> disabledWeathers;
 	private List<String> disabledEffects;
@@ -39,9 +42,12 @@ public class SeasonsConfig implements ConfigurationProvider {
 		}
 
 		daysPerSeason = config.getInt("DaysPerSeason");
+		startingYear = config.getInt("StartingYear");
+		seasonsPerYear = config.getInt("SeasonsPerYear");
 		secondsPerDamage = config.getInt("SecondsOfDamage");
 		roofHeight = config.getInt("RoofHeight");
 		enableEffects = config.getBoolean("CustomWeathers");
+		yearsEnabled = config.getBoolean("YearsEnabled");
 
 		if (config.getBoolean("ActionBar")) {
 			SeasonsActionBar.start();
@@ -49,6 +55,7 @@ public class SeasonsConfig implements ConfigurationProvider {
 			SeasonsActionBar.stop();
 		}
 
+		TitleMessageHandler.setOnYearChange(config.getBoolean("TitleMessages.year"));
 		TitleMessageHandler.setOnSeasonChange(config.getBoolean("TitleMessages.season"));
 		TitleMessageHandler.setOnWeatherChange(config.getBoolean("TitleMessages.weather"));
 
@@ -68,7 +75,7 @@ public class SeasonsConfig implements ConfigurationProvider {
 
 	@Override
 	public double getLatestVersion() {
-		return 4.0;
+		return 4.1;
 	}
 
 	@Override
@@ -85,10 +92,18 @@ public class SeasonsConfig implements ConfigurationProvider {
 	 * @return whether the update was successful. If false, values could not be injected and the config is out of date.
 	 */
 	public boolean attemptVersionInjection(JavaPlugin plugin, FileConfiguration config) {
-		if (getCurrentVersion() == 3) {
-			double versionUpdatingTo = 4.0;
-			config.set("TitleMessages.season", false);
-			config.set("TitleMessages.weather", false);
+		if (getCurrentVersion() < 4.1) {
+			double versionUpdatingTo = 4.1;
+			if (getCurrentVersion() == 3) {
+				config.set("TitleMessages.season", false);
+				config.set("TitleMessages.weather", false);
+			} else if (getCurrentVersion() == 4) {
+				config.set("YearsEnabled", true);
+				config.set("SeasonsPerYear", 4);
+				config.set("StartingYear", 2000);
+			} else return false;
+
+			config.set("TitleMessages.year", false);
 			config.set("version", versionUpdatingTo);
 			try {
 				config.save(getFile(plugin));
@@ -112,6 +127,20 @@ public class SeasonsConfig implements ConfigurationProvider {
 	}
 
 	/**
+	 * @return the year that the world starts on
+	 */
+	public int getStartingYear() {
+		return startingYear;
+	}
+
+	/**
+	 * @return the amount of seasons that must pass before the year increases
+	 */
+	public int getSeasonsPerYear() {
+		return seasonsPerYear;
+	}
+
+	/**
 	 * @return the amount of seconds which should pass between a player being damaged by an effect
 	 */
 	public int getSecondsPerDamage() {
@@ -130,6 +159,13 @@ public class SeasonsConfig implements ConfigurationProvider {
 	 */
 	public boolean hasEnabledEffects() {
 		return enableEffects;
+	}
+
+	/**
+	 * @return whether the years system has been enabled
+	 */
+	public boolean isYearsEnabled() {
+		return yearsEnabled;
 	}
 
 	/**

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/configuration/SeasonsLanguageConfiguration.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/configuration/SeasonsLanguageConfiguration.java
@@ -41,7 +41,7 @@ public class SeasonsLanguageConfiguration implements ConfigurationProvider {
 
 	@Override
 	public double getLatestVersion() {
-		return 4.0;
+		return 4.1;
 	}
 
 	@Override
@@ -50,10 +50,21 @@ public class SeasonsLanguageConfiguration implements ConfigurationProvider {
 	}
 
 	public boolean attemptVersionInjection(JavaPlugin plugin, FileConfiguration config) {
-		if (getCurrentVersion() == 3) {
-			double versionUpdatingTo = 4.0;
-			config.set("misc.weather-change", "&7The weather has changed");
-			config.set("misc.season-change", "&7The season has changed");
+		if (getCurrentVersion() < 4.1) {
+			if (getCurrentVersion() == 3) {
+				config.set("misc.weather-change", "&7The weather has changed");
+				config.set("misc.season-change", "&7The season has changed");
+			} else if (getCurrentVersion() == 4) {
+				config.set("misc.year-change", "&7The year has changed");
+				config.set("misc.year-color", "&c");
+				config.set("command.force-year", "&7Time shatters before you and now it is &bYear %year%");
+				List<String> season_info = config.getStringList("command.season-info");
+				season_info.add("&4If you have enabled the year please add the year here! Example: &c%year% &7- &a%season-number%&7/&c%seasons-per-year%");
+				config.set("command.season-info", season_info);
+				config.set("year-trigger", "&aEntered the %year%! Good luck!");
+			} else return false;
+
+			double versionUpdatingTo = 4.1;
 			config.set("version", versionUpdatingTo);
 			try {
 				config.save(getFile(plugin));

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/configuration/StaticPlaceholders.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/configuration/StaticPlaceholders.java
@@ -2,10 +2,13 @@ package uk.co.harieo.seasons.plugin.configuration;
 
 public enum StaticPlaceholders {
 
+	YEAR("year"),
 	SEASON("season"),
 	WEATHER("weather"),
 	DAY("day"),
 	MAX_DAYS("max-days"),
+	SEASON_NUMBER("season-number"),
+	SEASONS_PER_YEAR("seasons-per-year"),
 	OPTIONS("options"),
 	SEASON_COLOR("season-color");
 

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/events/YearChangeEvent.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/events/YearChangeEvent.java
@@ -1,0 +1,60 @@
+package uk.co.harieo.seasons.plugin.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import uk.co.harieo.seasons.plugin.models.Cycle;
+
+public class YearChangeEvent extends Event {
+
+    private Cycle cycle;
+    private int changeTo;
+    private int changeFrom;
+    private boolean naturalChange;
+
+    public YearChangeEvent(Cycle cycle, int changeTo, int changeFrom, boolean natural) {
+        this.cycle = cycle;
+        this.changeTo = changeTo;
+        this.changeFrom = changeFrom;
+        this.naturalChange = natural;
+    }
+
+    /**
+     * @return the {@link Cycle} this change effects
+     */
+    public Cycle getCycle() {
+        return cycle;
+    }
+
+    /**
+     * @return the year that the {@link Cycle} will change to
+     */
+    public int getChangedTo() {
+        return changeTo;
+    }
+
+    /**
+     * @return the year that the {@link Cycle} has changed from
+     */
+    public int getChangedFrom() {
+        return changeFrom;
+    }
+
+    /**
+     * @return whether the change was made by the automated system
+     */
+    public boolean isNaturalChange() {
+        return naturalChange;
+    }
+
+    private static final HandlerList handlers = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+}

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/models/Cycle.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/models/Cycle.java
@@ -13,12 +13,16 @@ public class Cycle {
 	private World world;
 	private Season season;
 	private Weather weather;
+	private int year;
+	private int seasonOfYear;
 	private int day;
 
-	public Cycle(World world, Season season, Weather weather, int day) {
+	public Cycle(World world, Season season, Weather weather, int year, int seasonOfYear, int day) {
 		this.world = world;
 		this.season = season;
 		this.weather = weather;
+		this.year = year;
+		this.seasonOfYear = seasonOfYear;
 		this.day = day;
 	}
 
@@ -44,6 +48,22 @@ public class Cycle {
 
 	public void setWeather(Weather weather) {
 		this.weather = weather;
+	}
+
+	public int getYear() {
+		return year;
+	}
+
+	public void setYear(int year) {
+		this.year = year;
+	}
+
+	public int getSeasonOfYear() {
+		return seasonOfYear;
+	}
+
+	public void setSeasonOfYear(int seasonOfYear) {
+		this.seasonOfYear = seasonOfYear;
 	}
 
 	public int getDay() {

--- a/plugin/src/main/java/uk/co/harieo/seasons/plugin/placeholders/SeasonsPlaceholderExpansion.java
+++ b/plugin/src/main/java/uk/co/harieo/seasons/plugin/placeholders/SeasonsPlaceholderExpansion.java
@@ -55,6 +55,12 @@ public class SeasonsPlaceholderExpansion extends PlaceholderExpansion {
 			type = RequestType.WEATHER;
 		} else if (identifier.startsWith("day")) {
 			type = RequestType.DAY;
+		} else if (identifier.startsWith("year")) {
+			if (Seasons.getInstance().getSeasonsConfig().isYearsEnabled()) {
+				type = RequestType.YEAR;
+			} else {
+				return null;
+			}
 		} else {
 			return null;
 		}
@@ -101,6 +107,8 @@ public class SeasonsPlaceholderExpansion extends PlaceholderExpansion {
 				return cycle.getSeason().getName();
 			} else if (type == RequestType.WEATHER) {
 				return cycle.getWeather().getName();
+			} else if (type == RequestType.YEAR) {
+				return String.valueOf(cycle.getYear());
 			} else {
 				return String.valueOf(cycle.getDay());
 			}
@@ -108,7 +116,7 @@ public class SeasonsPlaceholderExpansion extends PlaceholderExpansion {
 	}
 
 	public enum RequestType {
-		SEASON, WEATHER, DAY
+		SEASON, WEATHER, DAY, YEAR
 	}
 
 }

--- a/plugin/src/main/resources/lang.yml
+++ b/plugin/src/main/resources/lang.yml
@@ -41,6 +41,8 @@ seasons:
         autumn: 'A cool breeze whispers to the leaves that fall from the trees, it is %season%!'
         winter: 'A few snowflakes fall and the world grows cold, time for %season% to make its mark...'
 
+year-trigger: '&aEntered the %year%! Good luck!'
+
 effects:
     description:
         devastation: '&cYour hearts beats rapidly, yours legs tremble and you find you cannot regenerate health until this Devastation passes!'
@@ -102,7 +104,7 @@ command:
     effects-list-title: '&7For the weather &e%weather%, &7the effects are:'
     effects-list-element: '&6&l%effect%: &7%description%'
     season-info:
-        - '%season-color%Your world is in %season%'
+        - '%season-color%Your world is in %season% &7- &c%year% &7- &a%season-number%&7/&c%seasons-per-year%'
         - '&7The weather is currently &2%weather%'
         - '&eToday is Day %day% of %max-days%'
     season-info-footer: '&7To see the effects of this weather, use the command &e/seasons effects'
@@ -116,9 +118,12 @@ command:
     force-day: '&7Time shatters before you and now it is &bDay %day%'
     force-weather: '&7The skies grow silent and with a great rumble, the weather is now %weather%'
     force-season: '&7The air around you changes mystically and becomes %season%'
+    force-year: '&7Time shatters before you and now it is &bYear %year%'
 
 misc:
     prefix: '&e&lSeasons&7∙ &r'
     catastrophic-alert: '&c&lCATASTROPHIC WEATHER ALERT - Take care to plan your day'
     weather-change: '&7The weather has changed'
     season-change: '&7The season has changed'
+    year-change: '&7The year has changed'
+    year-color: '&c'


### PR DESCRIPTION
Implementing year logic. Closes #56.

I added YearsEnabled in config for disableable year system and I changed the attemptVersionInjection methods for making upgrading from an older version is possible.

Other changes are /changeyear command, year title and message when year is changed, year in actionbar, year placeholder and compatability with old version world datas. 

Changed the api-version to 1.13 because I got `Did you forget to define a modern (1.13+) api-version in your plugin.yml?` while running on 1.16. 

Tested on Spigot 1.12.2 and Paper 1.16.5.